### PR TITLE
Fix problem where sensor tracks wouldn't plot on map

### DIFF
--- a/stoqs/stoqs/templates/stoqs/stoqsquery.html
+++ b/stoqs/stoqs/templates/stoqs/stoqsquery.html
@@ -1281,7 +1281,7 @@
         if ($('#' + group + '-cmin').val() && $('#' + group + '-cmax').val()) {
             cmincmax = 'cmin=' + $('#' + group + '-cmin').val() + '&cmax=' + $('#' + group + '-cmax').val();
         }
-        if ($('body').data()[group + '_kmlurl']) {
+        if ($('body').data()[group + '_kmlurl'] && typeof cmincmax != 'undefined') {
             $('#' + group + '-kml-field').text($('body').data()[group + '_kmlurl'] + cmincmax);
             $('#' + group + '-kml-link').attr('href', $('body').data()[group + '_kmlurl'] + cmincmax);
         }


### PR DESCRIPTION
This problem was caused by overflow of data values in one of the Parameters in the database. This fix simply passes over attempts to get the min and max value for KML generation. The bad data can be seen in some of the activities in the statistics of nitrate (Parameter ID 38):

http://stoqs.shore.mbari.org:8000/stoqs_canon_september2015/api/activityparameter.html?parameter=38

There may be other problems resulting from these bad values being in the database. The ideal fix is to not load them in the first place, or to fix whatever problem is causing the overflow in the first place.