### PR TITLE
Return blank morelInfo if no nominal position for platform model

### DIFF
--- a/stoqs/utils/STOQSQManager.py
+++ b/stoqs/utils/STOQSQManager.py
@@ -573,6 +573,10 @@ class STOQSQManager(object):
                     geom = geom_list[0]
                 except IndexError:
                     return modelInfo
+
+                if not geom:
+                    return modelInfo
+
                 if len(geom_list) > 1:
                     logger.error('More than one location for %s returned.'
                                  'Using first one found: %s', platformName, geom)


### PR DESCRIPTION
Fixes initial "AJAX request for summary data failed" problem that cropped up for http://stoqs.mbari.org:8000/stoqs_os2016.