### PR TITLE
Add X3D Terrain for Lake Michigan to the load

### DIFF
--- a/stoqs/loaders/LakeMichigan/load_2016.py
+++ b/stoqs/loaders/LakeMichigan/load_2016.py
@@ -36,6 +36,16 @@ from thredds_crawler.etree import etree
 
 cl = LakeMILoader('stoqs_michigan2016', 'Lake Michigan LRAUV Experiment 2016',
                     description = 'LRAUV 2016 Experiment in Lake Michigan',
+                    x3dTerrains = {
+                                    'http://stoqs.mbari.org/x3d/michigan_lld_10x/michigan_lld_10x_src_scene.x3d': {
+                                        'position': '277414.36721 -5207201.16684 4373105.96194',
+                                        'orientation': '0.99821 -0.05662 0.01901 1.48579',
+                                        'centerOfRotation': '281401.0288298179 -4639090.577582279 4354217.4974804',
+                                        'VerticalExaggeration': '10',
+                                        'speed': '0.1',
+                                    }
+                    },
+                    grdTerrain = os.path.join(parentDir, 'michigan_lld.grd')
                   )
 
 # Set start and end dates for all loads from sources that contain data
@@ -143,6 +153,8 @@ if cl.args.test:
 else:
     cl.loadTethys()
 
+# Add any X3D Terrain information specified in the constructor to the database - must be done after a load is executed
+cl.addTerrainResources()
 
 print "All Done."
 


### PR DESCRIPTION
The NetCDF file from https://www.ngdc.noaa.gov/mgg/greatlakes/michigan.html should be added to the stoqs/loaders directory so that altitude can be computed.