### PR TITLE
Fix setting of Activity min and max depths during load

### DIFF
--- a/stoqs/loaders/__init__.py
+++ b/stoqs/loaders/__init__.py
@@ -1109,7 +1109,9 @@ class STOQS_Loader(object):
         '''
         Pull the min & max depth from Measurement and set the Activity mindepth and maxdepth
         '''
-        m_qs = m.Measurement.objects.using(self.dbAlias).aggregate(Max('depth'), Min('depth'))
+        m_qs = (m.Measurement.objects.using(self.dbAlias)
+                        .filter(instantpoint__activity__id=self.activity.id)
+                        .aggregate(Max('depth'), Min('depth')))
         m.Activity.objects.using(self.dbAlias).filter(id=self.activity.id).update(
                                                         mindepth = m_qs['depth__min'],
                                                         maxdepth = m_qs['depth__max'])

--- a/stoqs/mbari_campaigns.py
+++ b/stoqs/mbari_campaigns.py
@@ -54,7 +54,7 @@ campaigns = OrderedDict([
     ('stoqs_os2015',             'CANON/loadCANON_os2015.py'),
     ('stoqs_canon_september2015',   'CANON/loadCANON_september2015.py'),
     ('stoqs_os2016',             'CANON/loadCANON_os2016.py'),
-    ('stoqs_cce2015',            'BEDS/loadCCE_2015.py'),
+    ('stoqs_cce2015',            'CCE/loadCCE_2015.py'),
     ('stoqs_michigan2016',       'LakeMichigan/load_2016.py'),
     ('stoqs_canon_september2016',   'CANON/loadCANON_september2016.py'),
 ])

--- a/stoqs/utils/STOQSQManager.py
+++ b/stoqs/utils/STOQSQManager.py
@@ -201,7 +201,7 @@ class STOQSQManager(object):
         # Assign query sets for the current UI selections
         if fromTable == 'Activity':
             self.qs = qs.using(self.dbname)
-            self.qs_platform = qs_platform.using(self.dbname)
+            self.qs_platform = qs_platform
             ##logger.debug('Activity query = %s', str(self.qs.query))
         elif fromTable == 'Sample':
             self.sample_qs = qs.using(self.dbname)


### PR DESCRIPTION
It's a bit embarrassing that [this bug](https://github.com/stoqs/stoqs/compare/master...MBARIMike:master#diff-cae62b16781823905eaf402f6b07288aL1112) has been the code for so long.

It causes spatial temporal queries of summary overview data to be much slower and causes incorrect display of Platforms and Parameters when the selection is zoomed in depth and time.

If convenient, data should be reloaded to fix existing databases.