### PR TITLE
Removed LRAUV code block propagated the activity name between appende…

### DIFF
--- a/stoqs/loaders/LakeMichigan/monitorLrauv.py
+++ b/stoqs/loaders/LakeMichigan/monitorLrauv.py
@@ -317,11 +317,6 @@ if __name__ == '__main__':
                 # Return datetime of last timevalue - if data are loaded from multiple activities return the earliest last datetime value
                 dataStartDatetime = InstantPoint.objects.using(args.database).filter(activity__name__contains=core_aName).aggregate(Max('timevalue'))['timevalue__max']
 
-            if dataStartDatetime:
-                # Override the activity name with what's in the database. Arbitrarily pick the first one.
-                ip = InstantPoint.objects.using(args.database).filter(activity__name__contains=core_aName)
-                aName = ip[0].activity.name
-
             try:
                 if not args.debug:
                     logger.info("Instantiating Lrauv_Loader for url = %s", url_src)


### PR DESCRIPTION
…d loads; this was a workaround to append loads to the same activity name and should now be fixed with pull request 365 https://github.com/stoqs/stoqs/pull/365