### PR TITLE
Use matplotlib's 'Agg' to avoid 'No module named _tkinter' error

### DIFF
--- a/stoqs/loaders/CANON/__init__.py
+++ b/stoqs/loaders/CANON/__init__.py
@@ -40,6 +40,8 @@ from argparse import Namespace
 from nettow import NetTow
 from planktonpump import PlanktonPump
 import logging
+import matplotlib as mpl
+mpl.use('Agg')               # Force matplotlib to not use any Xwindows backend
 import matplotlib.pyplot as plt
 from matplotlib.colors import rgb2hex
 import numpy as np


### PR DESCRIPTION
See http://stackoverflow.com/questions/4931376/generating-matplotlib-graphs-without-a-running-x-server/4935945#4935945