### PR TITLE
update loadCANON_september2016.py

### DIFF
--- a/stoqs/loaders/CANON/loadCANON_september2016.py
+++ b/stoqs/loaders/CANON/loadCANON_september2016.py
@@ -68,13 +68,13 @@ for name in ['load_{}'.format(s) for s in cl.roms_platforms]:
 
 cl.roms_sg621_base = cl.dodsBase + 'CANON/2016_Sep/Platforms/ROMS/'
 cl.roms_sg621_files = ['roms_sg621_{:04d}.nc'.format(i) for i in range(248,400)]
-cl.roms_sg621_parms = ['roms_temperature', 'roms_salinity', 'roms_spice', 'roms_spice', 'temperature', 'salinity', 'spice']
+cl.roms_sg621_parms = ['roms_temperature', 'roms_salinity', 'roms_spice', 'temperature', 'salinity', 'spice']
 cl.roms_sg621_start_datetime = startdate
 cl.roms_sg621_end_datetime = enddate
 
 cl.roms_spray_base = cl.dodsBase + 'CANON/2016_Sep/Platforms/ROMS/'
 cl.roms_spray_files = ['roms_spray_{:04d}.nc'.format(i) for i in range(313,450)]
-cl.roms_spray_parms = ['roms_temperature', 'roms_salinity', 'roms_spice', 'roms_spice', 'temperature', 'salinity', 'spice']
+cl.roms_spray_parms = ['roms_temperature', 'roms_salinity', 'roms_spice', 'temperature', 'salinity', 'spice']
 cl.roms_spray_start_datetime = startdate
 cl.roms_spray_end_datetime = enddate
 


### PR DESCRIPTION
remove duplicated "roms_spice" parameter from parameter list for the two roms simulated glider platforms (roms_sg621 and roms_spray)