### PR TITLE
Fix error on loading 2nd Activity with previously ignored names 

### DIFF
--- a/stoqs/loaders/DAPloaders.py
+++ b/stoqs/loaders/DAPloaders.py
@@ -113,14 +113,6 @@ class Base_Loader(STOQS_Loader):
     as done by the monitorLrauv.py script in the realtime folder.  This
     use has not been fully tested.
     '''
-    parameter_dict={} # used to cache parameter objects 
-    standard_names = {} # should be defined for each child class
-    include_names=[] # names to include, if set it is used in conjunction with ignored_names
-    # Note: if a name is both in include_names and ignored_names it is ignored.
-    ignored_names=[]  # Should be defined for each child class
-    global_ignored_names = ['longitude','latitude', 'time', 'Time',
-                'LONGITUDE','LATITUDE','TIME', 'NominalDepth', 'esecs', 'Longitude', 'Latitude',
-                'DEPTH','depth'] # A list of parameters that should not be imported as parameters
     def __init__(self, activityName, platformName, url, dbAlias='default', campaignName=None, campaignDescription=None,
                 activitytypeName=None, platformColor=None, platformTypeName=None, 
                 startDatetime=None, endDatetime=None, dataStartDatetime=None, auxCoords=None, stride=1,
@@ -193,7 +185,7 @@ class Base_Loader(STOQS_Loader):
             logger.error('Failed in attempt to open_url("%s")', url)
             raise
 
-        self.ignored_names += self.global_ignored_names # add global ignored names to platform specific ignored names.
+        self.ignored_names = list(self.global_ignored_names)    # Start with copy of list of global ignored names
         self.build_standard_names()
 
     def _getStartAndEndTimeFromDS(self):
@@ -642,7 +634,7 @@ class Base_Loader(STOQS_Loader):
             except KeyError as e:
                 if self.getFeatureType() == 'trajectory':
                     # Assume that it's a derived variable and add same count as 
-                    logger.warn("%s: Assuming it's a derived parameter", e)
+                    logger.debug("%s: Assuming it's a derived parameter", e)
                     numDerived += 1
                     
         logger.debug('Adding %d derived parameters of length %d to the count', numDerived, trajSingleParameterCount / self.stride)
@@ -1096,8 +1088,10 @@ class Base_Loader(STOQS_Loader):
                 try:
                     logger.debug('Checking for %s in self.include_names', key)
                     if len(self.include_names) and key not in self.include_names:
+                        logger.debug('%s is not in self.include_names', key)
                         continue
                     elif key in self.ignored_names:
+                        logger.debug('%s is in self.ignored_names', key)
                         continue
 
                     # Mooring tstring/adcp and Dorado LOPC data: value will be an array.
@@ -1343,7 +1337,6 @@ class Base_Loader(STOQS_Loader):
             elif self.getFeatureType().lower() == 'trajectoryprofile':
                 self.insertSimpleDepthTimeSeriesByNominalDepth(trajectoryProfileDepths=self.timeDepthProfiles)
             logger.info("Data load complete, %d records loaded.", self.loaded)
-
 
             return self.loaded, path, parmCount
 
@@ -1697,6 +1690,7 @@ def runBEDTrajectoryLoader(url, cName, cDesc, aName, pName, pColor, pTypeName, a
 
     logger.debug("Setting include_names to %s", parmList)
     loader.include_names = parmList
+    logger.debug("loader.ignored_names = %s", loader.ignored_names)
 
     if plotTimeSeriesDepth:
         # Used first for BEDS where we want both trajectory and timeSeries plots - assumes starting depth of BED

--- a/stoqs/loaders/__init__.py
+++ b/stoqs/loaders/__init__.py
@@ -308,9 +308,9 @@ class STOQS_Loader(object):
     include_names=[] # names to include, if set it is used in conjunction with ignored_names
     # Note: if a name is both in include_names and ignored_names it is ignored.
     ignored_names=[]  # Should be defined for each child class
-    global_ignored_names = ['longitude','latitude', 'time', 'Time',
+    global_ignored_names = ('longitude','latitude', 'time', 'Time',
                 'LONGITUDE','LATITUDE','TIME', 'NominalDepth', 'esecs', 'Longitude', 'Latitude',
-                'DEPTH','depth'] # A list of parameters that should not be imported as parameters
+                'DEPTH','depth') # A list (tuple) of parameters that should not be imported as parameters
     global_dbAlias = ''
 
     logger = logging.getLogger('__main__')
@@ -620,10 +620,12 @@ class STOQS_Loader(object):
             except KeyError as e:
                 # Just skip derived parameters that may have been added for a sub-classed Loader
                 if v != 'altitude':
-                    self.logger.warn('include_name %s is not in %s; assuming it is derived and skipping', v, self.url)
+                    self.logger.warn('include_name %s is not in %s - skipping', v, self.url)
             except AttributeError as e:
                 # Just skip over loaders that don't have the plotTimeSeriesDepth attribute
                 self.logger.warn('%s for include_name %s in %s. Skipping', e, v, self.url)
+            except ParameterNotFound as e:
+                self.logger.warn('Could not get Parameter for v = %s: %s', v, e)
 
         self.logger.info('Adding plotTimeSeriesDepth Resource for Parameters we want plotted in Parameter tab')
         for v in self.include_names + ['altitude']:
@@ -691,7 +693,6 @@ class STOQS_Loader(object):
             print e
             print name
             pprint.pprint( self.parameter_dict[name])
-
 
         return self.parameter_dict[name]
 


### PR DESCRIPTION
This was a strange error to discover and fix.

I discovered it after adding AXIS_X, ..., ROT_Z variables to BED NetCDF files and then trying to load one of the new files after loading a file without these new variables. DAPloaders.py was setting the global_ignored_names to ignored_names to which the new variables were added. The bug was in this line:

```python
self.ignored_names += self.global_ignored_names
```
All beginning Python books warn about assigning lists this way: copy by address. So `self.global_ignored_names` ended up having all the new variable names added to it and then they became `self.ignored_names` on the 2nd Activity load.