### PR TITLE
Add scalefactor of 2 to the LRAUV models

### DIFF
--- a/stoqs/loaders/CANON/__init__.py
+++ b/stoqs/loaders/CANON/__init__.py
@@ -161,7 +161,8 @@ class CANONLoader(LoadScript):
             except DAPloaders.NoValidData:
                 self.logger.info("No valid data in %s" % url)
 
-        self.addPlatformResources('http://stoqs.mbari.org/x3d/lrauv/lrauv_tethys.x3d', pName)
+        self.addPlatformResources('http://stoqs.mbari.org/x3d/lrauv/lrauv_tethys.x3d', pName,
+                                  scalefactor=2)
 
     def loadDaphne(self, stride=None):
         '''
@@ -181,6 +182,8 @@ class CANONLoader(LoadScript):
             except DAPloaders.NoValidData:
                 self.logger.info("No valid data in %s" % url)
 
+        self.addPlatformResources('http://stoqs.mbari.org/x3d/lrauv/lrauv_daphne.x3d', pName,
+                                  scalefactor=2)
 
     def loadMakai(self, stride=None):
         '''
@@ -201,7 +204,8 @@ class CANONLoader(LoadScript):
             except DAPloaders.NoValidData:
                 self.logger.info("No valid data in %s" % url)
 
-        self.addPlatformResources('http://stoqs.mbari.org/x3d/lrauv/lrauv_makai.x3d', pName)
+        self.addPlatformResources('http://stoqs.mbari.org/x3d/lrauv/lrauv_makai.x3d', pName,
+                                  scalefactor=2)
 
     def loadAku(self, stride=None):
         '''
@@ -222,7 +226,8 @@ class CANONLoader(LoadScript):
             except DAPloaders.NoValidData:
                 self.logger.info("No valid data in %s" % url)
 
-        self.addPlatformResources('http://stoqs.mbari.org/x3d/lrauv/lrauv_aku.x3d', pName)
+        self.addPlatformResources('http://stoqs.mbari.org/x3d/lrauv/lrauv_aku.x3d', pName,
+                                  scalefactor=2)
 
     def loadAhi(self, stride=None):
       '''


### PR DESCRIPTION
The LRAUV models also needed to be translated by '-.55 -.35 -.45' as the export from SolidWorks did not have the center in the center of the vehicle. This was done directly to the files in http://stoqs.mbari.org/x3d/lrauv.