### PR TITLE
Remove Python 3.6 from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.6"
 addons:
   postgresql: "9.4"
 services:


### PR DESCRIPTION
A more careful examination of the travis-ci log shows that upgrading to Python 3.6 is a bit more involved; miniconda needs to be updated too. 

This development should happen on a separate branch so that all other necessary changes (provision.sh, requirements, code changes) can be made in concert without affecting master.