### PR TITLE
Trap bad angles and give a warning

### DIFF
--- a/stoqs/utils/Viz/animation.py
+++ b/stoqs/utils/Viz/animation.py
@@ -8,6 +8,7 @@ import math
 import numpy as np
 import os
 import time
+import traceback
 from collections import namedtuple
 from datetime import datetime
 from itertools import izip, izip_longest
@@ -344,7 +345,13 @@ class PlatformAnimation(object):
     def _deg2rad(self, angle):
         '''Given an angle in degrees return angle in radians
         '''
-        return np.pi * angle / 180.0
+        try:
+            return np.pi * angle / 180.0
+        except TypeError:
+            axis = [el for el in  traceback.format_stack() if '_deg2rad' in el
+                    ][0].split('_deg2rad(')[1].split(')')[0]
+            self.logger.warn("Bad %s angle: %s", axis, angle)
+            return 0.0
 
     def _pitch_with_ve(self, angle, ve):
         '''Given an angle in degrees return pitch angle in radians properly


### PR DESCRIPTION
Noticed that there was one 'None' value in in roll data from http://dods.mbari.org/opendap/data/auvctd/surveys/2017/netcdf/Dorado389_2017_068_00_068_00_decim.nc.html. This fix replaces None values with 0.0 and prints a warning to the server log.