### PR TITLE
Add black edgecolor to scatter plot of Sample locations

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,7 +42,7 @@ PasteScript==2.0.2
 Pillow==4.0.0
 psycopg2==2.6.2
 pupynere==1.0.15
-Pydap==3.2.0
+Pydap==3.2.1
 python-dateutil==2.6.0
 python-memcached==1.58
 python-openid==2.2.5

--- a/stoqs/utils/Viz/plotting.py
+++ b/stoqs/utils/Viz/plotting.py
@@ -623,13 +623,13 @@ class MeasuredParameter(BaseParameter):
                 if self.sampleQS and SAMPLED not in self.parameterGroups:
                     # Sample markers for everything but Net Tows
                     xsamp, ysamp, sname = self._get_samples_for_markers(exclude_act_name=NETTOW)
-                    ax.scatter(xsamp, np.float64(ysamp), marker='o', c='w', s=15, zorder=10)
+                    ax.scatter(xsamp, np.float64(ysamp), marker='o', c='w', s=15, zorder=10, edgecolors='k')
                     for x,y,sn in izip(xsamp, ysamp, sname):
                         plt.annotate(sn, xy=(x,y), xytext=(5,-5), textcoords = 'offset points', fontsize=7)
 
                     # Annotate NetTow Samples at Sample record location - points
                     xsamp, ysamp, sname = self._get_samples_for_markers(act_name=NETTOW)
-                    ax.scatter(xsamp, np.float64(ysamp), marker='o', c='w', s=15, zorder=10)
+                    ax.scatter(xsamp, np.float64(ysamp), marker='o', c='w', s=15, zorder=10, edgecolors='k')
                     for x,y,sn in izip(xsamp, ysamp, sname):
                         plt.annotate(sn, xy=(x,y), xytext=(5,-5), textcoords = 'offset points', fontsize=7)
 
@@ -637,7 +637,7 @@ class MeasuredParameter(BaseParameter):
                     xspan, yspan, sname = self._get_samples_for_markers(act_name=VERTICALNETTOW, spanned=True)
                     for xs,ys in zip(xspan, yspan):
                         ax.plot(xs, ys, c='k', lw=2)
-                        ax.scatter([xs[1]], [0], marker='o', c='w', s=15, zorder=10)
+                        ax.scatter([xs[1]], [0], marker='o', c='w', s=15, zorder=10, edgecolors='k')
 
                 if full_screen:
                     fig.savefig(sectionPngFileFullPath, dpi=240, transparent=True)
@@ -1102,12 +1102,12 @@ class ParameterParameter(BaseParameter):
                     if self.c:
                         try:
                             ax.scatter(self.sx, self.sy, marker='o', c=self.c, s=25, cmap=self.cm, 
-                                       vmin=self.pMinMax['c'][1], vmax=self.pMinMax['c'][2], clip_on=False)
+                                       vmin=self.pMinMax['c'][1], vmax=self.pMinMax['c'][2], clip_on=False, edgecolors='k')
                         except ValueError as e:
                             # Likely because a Measured Parameter has been selected for color and len(self.c) != len(self.sx)
-                            ax.scatter(self.sx, self.sy, marker='o', c='w', s=25, zorder=10, clip_on=False)
+                            ax.scatter(self.sx, self.sy, marker='o', c='w', s=25, zorder=10, clip_on=False, edgecolors='k')
                     else:
-                        ax.scatter(self.sx, self.sy, marker='o', c='w', s=25, zorder=10, clip_on=False)
+                        ax.scatter(self.sx, self.sy, marker='o', c='w', s=25, zorder=10, clip_on=False, edgecolors='k')
                     for i, txt in enumerate(self.sample_names):
                         ax.annotate(txt, xy=(self.sx[i], self.sy[i]), xytext=(3.0, 3.0), textcoords='offset points')
             


### PR DESCRIPTION
Underlying upgrades of Matplotlib must have removed the black edge of the Sample location circles. This PR adds the `edgecolors='k'` argument to the `scatter()` calls.