### PR TITLE
Pass over ValueError if system doesn't have 'eth0' interface

### DIFF
--- a/stoqs/config/settings/common.py
+++ b/stoqs/config/settings/common.py
@@ -94,6 +94,9 @@ try:
 except ImportError:
     # Likely because 'netifaces' has not been installed
     pass
+except ValueError:
+    # Likely because 'eth0' is not a network interface on this system
+    pass
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=default_allowed_hosts)
 


### PR DESCRIPTION
Previous addition to default_allowed_hosts of 'eth0' host was required for MBARI server, but 'eth0' doesn't exist on all OSs, e.g. CentOS 7 uses interface 'enp0s3'.