### PR TITLE
add platforms; deal with changes in platforms, loadCANON_april2017

### DIFF
--- a/stoqs/loaders/CANON/__init__.py
+++ b/stoqs/loaders/CANON/__init__.py
@@ -67,6 +67,7 @@ class CANONLoader(LoadScript):
                 'waveglider':   'c7eae5',
                 'nps_g29':      '80cdc1',
                 'l_662':        '35978f',
+                'l_662a':       '38978f',
                 'm1':           '35f78f',
                 'm2':           '35f780',
                 'martin':       '01665e',
@@ -85,8 +86,11 @@ class CANONLoader(LoadScript):
                 'waveglider':   'fc4e2a',
                 'nps_g29':      'e31a1c',
                 'l_662':        'bd0026',
+                'l_662a':       'bd008f',
                 'nps29':        '0b9131',
                 'nps34':        '36d40f',
+                'nps34a':        '36d40f',
+                'sg539':        '5f9131',
                 'sg621':        '5b9131',
                 'm1':           'bd2026',
                 'm2':           'bd2020',
@@ -348,6 +352,19 @@ class CANONLoader(LoadScript):
                                        self.l_662_endDatetime, grdTerrain=self.grdTerrain,
                                        command_line_args=self.args)
 
+    def loadL_662a(self, stride=None):
+        '''
+        Glider specific load functions
+        '''
+        stride = stride or self.stride
+        for (aName, f) in zip([ a + getStrideText(stride) for a in self.l_662a_files], self.l_662a_files):
+            url = self.l_662a_base + f
+            DAPloaders.runGliderLoader(url, self.campaignName, self.campaignDescription, aName,
+                                       'SPRAY_L66a_Glider', self.colors['l_662a'], 'glider', 'Glider Mission',
+                                       self.l_662a_parms, self.dbAlias, stride, self.l_662a_startDatetime,
+                                       self.l_662a_endDatetime, grdTerrain=self.grdTerrain,
+                                       command_line_args=self.args)
+
     def load_NPS29(self, stride=None):
         '''
         Glider specific load functions
@@ -360,6 +377,22 @@ class CANONLoader(LoadScript):
                                         self.nps29_parms, self.dbAlias, stride, self.nps29_startDatetime, 
                                         self.nps29_endDatetime, grdTerrain=self.grdTerrain, 
                                         command_line_args=self.args)
+
+    def load_SG539(self, stride=None):
+        '''
+        Glider specific load functions
+        '''
+        stride = stride or self.stride
+        for (aName, f) in zip([ a + getStrideText(stride) for a in self.sg539_files], self.sg539_files):
+            url = self.sg539_base + f
+            try:
+                DAPloaders.runGliderLoader(url, self.campaignName, self.campaignDescription, aName,
+                                       'SG_Glider_539', self.colors['sg539'], 'glider', 'Glider Mission',
+                                        self.sg539_parms, self.dbAlias, stride, self.sg539_startDatetime,
+                                        self.sg539_endDatetime, grdTerrain=self.grdTerrain,
+                                        command_line_args=self.args)
+            except (DAPloaders.OpendapError, DAPloaders.NoValidData) as e:
+                self.logger.warn(str(e))
 
     def load_SG621(self, stride=None):
         '''
@@ -389,6 +422,20 @@ class CANONLoader(LoadScript):
                                         self.nps34_parms, self.dbAlias, stride, self.nps34_startDatetime, 
                                         self.nps34_endDatetime, grdTerrain=self.grdTerrain,
                                         command_line_args=self.args)
+
+    def load_NPS34a(self, stride=None):
+        '''
+        Glider specific load functions
+        '''
+        stride = stride or self.stride
+        for (aName, f) in zip([ a + getStrideText(stride) for a in self.nps34a_files], self.nps34a_files):
+            url = self.nps34a_base + f
+            DAPloaders.runGliderLoader(url, self.campaignName, self.campaignDescription, aName,
+                                       'NPS_Glider_34', self.colors['nps34a'], 'glider', 'Glider Mission',
+                                        self.nps34a_parms, self.dbAlias, stride, self.nps34a_startDatetime,
+                                        self.nps34a_endDatetime, grdTerrain=self.grdTerrain,
+                                        command_line_args=self.args)
+
 
     def load_glider_ctd(self, stride=None):
         '''

--- a/stoqs/loaders/CANON/loadCANON_april2017.py
+++ b/stoqs/loaders/CANON/loadCANON_april2017.py
@@ -203,7 +203,7 @@ cl.sg539_endDatetime = enddate
 # SG_621 ## KISS glider from Caltech/JPL
 cl.sg621_base = cl.dodsBase + 'CANON/2017_APR/Platforms/Gliders/Seaglider/'
 cl.sg621_files = ['p621{:04d}.nc'.format(i) for i in range(48,421)] ## index needs to be 1 higher than terminal file name
-cl.sg621_parms = ['temperature', 'salinity']
+cl.sg621_parms = ['temperature', 'salinity', 'aanderaa4330_dissolved_oxygen']
 cl.sg621_startDatetime = startdate
 cl.sg621_endDatetime = enddate
 

--- a/stoqs/loaders/CANON/loadCANON_april2017.py
+++ b/stoqs/loaders/CANON/loadCANON_april2017.py
@@ -380,6 +380,8 @@ else:
     cl.load_NPS34()
     cl.load_NPS34a()
     cl.load_slocum_nemesis()
+    cl.load_SG621(stride=2) ## KISS glider
+    cl.load_SG539(stride=2) ## KISS glider
     cl.load_wg_Tiny()
     cl.load_oa1()
     cl.load_oa2()

--- a/stoqs/loaders/CANON/loadCANON_april2017.py
+++ b/stoqs/loaders/CANON/loadCANON_april2017.py
@@ -184,6 +184,48 @@ cl.l_662_parms = ['TEMP', 'PSAL', 'FLU2']
 cl.l_662_startDatetime = startdate
 cl.l_662_endDatetime = enddate
 
+# Glider data files from CeNCOOS thredds server
+# L_662a updated parameter names in netCDF file
+cl.l_662a_base = 'http://legacy.cencoos.org/thredds/dodsC/gliders/Line66/'
+cl.l_662a_files = [
+                   'OS_Glider_L_662_20170328_TS.nc'  ]
+cl.l_662a_parms = ['temperature', 'salinity', 'fluorescence','oxygen']
+cl.l_662a_startDatetime = startdate
+cl.l_662a_endDatetime = enddate
+
+# SG_539 ## KISS glider from Caltech/JPL
+cl.sg539_base = cl.dodsBase + 'CANON/2017_Apr/Platforms/Gliders/Seaglider/'
+cl.sg539_files = ['p539{:04d}.nc'.format(i) for i in range(48,421)] ## index needs to be 1 higher than terminal file name
+cl.sg539_parms = ['temperature', 'salinity']
+cl.sg539_startDatetime = startdate
+cl.sg539_endDatetime = enddate
+
+# SG_621 ## KISS glider from Caltech/JPL
+cl.sg621_base = cl.dodsBase + 'CANON/2017_APR/Platforms/Gliders/Seaglider/'
+cl.sg621_files = ['p621{:04d}.nc'.format(i) for i in range(48,421)] ## index needs to be 1 higher than terminal file name
+cl.sg621_parms = ['temperature', 'salinity']
+cl.sg621_startDatetime = startdate
+cl.sg621_endDatetime = enddate
+
+
+# NPS_34a updated parameter names in netCDF file
+## The following loads decimated subset of data telemetered during deployment
+cl.nps34a_base = 'http://legacy.cencoos.org/thredds/dodsC/gliders/Line66/'
+cl.nps34a_files = [ 'OS_Glider_NPS_G34_20170405_TS.nc' ]
+cl.nps34a_parms = ['temperature', 'salinity','fluorescence']
+cl.nps34a_startDatetime = startdate
+cl.nps34a_endDatetime = enddate
+
+# Slocum Teledyne nemesis Glider
+## from ioos site
+cl.slocum_nemesis_base = 'https://data.ioos.us/gliders/thredds/dodsC/deployments/mbari/Nemesis-20170412T0000/'
+cl.slocum_nemesis_files = [ 'Nemesis-20170412T0000.nc3.nc' ]
+## cl.slocum_nemesis_base = cl.dodsBase + 'CANON_september2013/Platforms/Gliders/Slocum_Teledyne/final/'
+## cl.slocum_nemesis_files = [ 'glider-nemesis_20130716T221027_rt0.nc' ]
+cl.slocum_nemesis_parms = [ 'temperature', 'salinity', 'u', 'v' ]
+cl.slocum_nemesis_startDatetime = startdate
+cl.slocum_nemesis_endDatetime = enddate
+
 ######################################################################
 # Wavegliders
 ######################################################################
@@ -334,7 +376,10 @@ else:
     cl.loadAhi()
     cl.loadOpah()
     cl.loadL_662()
+    cl.loadL_662a()
     cl.load_NPS34()
+    cl.load_NPS34a()
+    cl.load_slocum_nemesis()
     cl.load_wg_Tiny()
     cl.load_oa1()
     cl.load_oa2()


### PR DESCRIPTION
add new platforms (gliders) to loadCANON_april2017 loader. add the platforms to __init__.py as needed. Deal with changes in netCDF variable names introduced by Fred B. to address IOOS conventions for netCDF by creating "new" platforms that have these new variables, while retaining the "old" platforms with the old variables that are used by legacy loaders.