### PR TITLE
Add load of ADCP data to the CCE BIN - improve speed of valid data check

### DIFF
--- a/stoqs/loaders/CCE/loadCCE_2015.py
+++ b/stoqs/loaders/CCE/loadCCE_2015.py
@@ -174,10 +174,14 @@ cl.ccebin_files = [
                     'MBCCE_BIN_CTD_20151013_timecorrected.nc',
                     'MBCCE_BIN_OXY_20151013_timecorrected.nc',
                     'MBCCE_BIN_ECO_20151013_timecorrected.nc',
+                    'MBCCE_BIN_ADCP300_20151013.nc',
+                    'MBCCE_BIN_ADCP1200_20151013.nc',
+                    'MBCCE_BIN_ADCP1200_20151013.nc'
                   ]
 cl.ccebin_parms = [ 'pressure', 'temperature', 'conductivity', 'turbidity', 'optical_backscatter',
                     'oxygen', 'saturation', 'optode_temperature',
-                    'chlor', 'ntu1', 'ntu2' ]
+                    'chlor', 'ntu1', 'ntu2',
+                    'u_1205', 'v_1206', 'w_1204', 'AGC_1202', 'Hdg_1215', 'Ptch_1216', 'Roll_1217']
 
 # MS1 ADCP data
 cl.ccems1_nominal_depth = 225

--- a/stoqs/loaders/__init__.py
+++ b/stoqs/loaders/__init__.py
@@ -795,14 +795,15 @@ class STOQS_Loader(object):
         self.logger.info("Checking for valid data from %s", self.url)
         self.logger.debug("include_names = %s", self.include_names)
         for v in self.include_names:
-            self.logger.debug("v = %s", v)
+            allNaNFlag[v] = True
+            self.logger.info("include_name: %s", v)
             try:
-                try:
-                    allNaNFlag[v] = np.isnan(self.ds[v][:]).all()
-                except TypeError:
-                    allNaNFlag[v] = np.isnan(self.ds[v].array).all()
-                if not allNaNFlag[v]:
-                    anyValidData = True
+                for value in self.ds[v].array[:].flatten():
+                    if not np.isnan(value).all():
+                        allNaNFlag[v] = False
+                        anyValidData = True
+                        break
+
             except KeyError:
                 self.logger.debug('Parameter %s not in %s. Skipping.', v, self.ds.keys())
                 if v.find('.') != -1:


### PR DESCRIPTION
The BIN ADCP NetCDF files are about 2 GB in size and the previous checkForValidData() would examine every data value to determine if there were any non-NaN data, which took a looong time.