### PR TITLE
Refine VM configuration and instructions for using PyCharm

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ vagrant up --provider virtualbox
 ```
 
 The `vagrant up` command takes an hour or so to provision and setup a complete CentOS 7 
-STOQS server that also includes MB-System, InstantReality, and all the Python data science 
-tools bundled in packages such as Anaconda.  All connections to this virtual machine are 
+STOQS Virtual Machine that also includes MB-System, InstantReality, and all the Python data science 
+tools bundled in packages such as Anaconda.  You will be prompted for your admin password
+for configuring a shared folder from the VM.  All connections to this VM are 
 performed from the the directory you installed it in; you must cd to it (e.g. `cd
 ~/Vagrants/stoqsvm`) before logging in with the `vagrant ssh -- -X` command.  After 
-installation finishes log into your new virtual machine and test it:
+installation finishes log into your new VM and test it:
 
 ```bash
 vagrant ssh -- -X   # Wait for [vagrant@localhost ~]$ prompt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,5 +17,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, host: 8080, guest: 80
   config.ssh.forward_x11 = true
   config.ssh.insert_key = false
+  config.vm.network :private_network, ip: '192.168.50.50'
+  config.vm.synced_folder '.', '/vagrant', nfs: true
   config.vm.provision "shell", path: "provision.sh"
 end

--- a/doc/instructions/PYCHARM.md
+++ b/doc/instructions/PYCHARM.md
@@ -10,29 +10,22 @@ Instructions for Setting up PyCharm to work in your VM
    it via the menu in Tools -> Vagrant.
 
 
-### Make sure sftpd-server is properly configured in your VM
-
-1. cd ~/Vagrants/stoqsvm_python3/ && vagrant ssh -- -X
-
-2. sudo vi /etc/ssh/sshd_config
-
-3. Change line from `Subsystem sftp /usr/lib/openssh/sftp-server` to `Subsystem sftp /usr/libexec/openssh/sftp-server`
-
-4. Restart sshd:
-
-        sudo /usr/bin/systemctl restart sshd
-
-
 ### Setting up PyCharm Project Interpretor and Project Structure (on MacOS)
 
-1. From PyCharm open Preferences -> Project: stoqsvm -> Project Interpreter:
+1. From PyCharmi, open Preferences -> Project: stoqsvm [1] -> Project Interpreter:
     * Click on the 3-dot icon to the right of the Project Interpreter selector
+    * Select 'Add Remote'
     * Check Vagrant
+    * Ensure that the Vagrant Instance Fold... is pointing to the correct path
     * Click on the 3-dot icon to the right of Python interpreter path text box, select 'Yes' to connect to remote host
-    * Navigate to '/home/vagrant/dev/stoqsgit/venv-stoqs/bin/python' and click OK
+    * Navigate to '/vagrant/dev/stoqsgit/venv-stoqs/bin/python' and click OK
     * Click OK on the Preferences dialog window
 
 2. Wait a few minutes for PyCharm to connect to your VM and build its project files (which are kept in the .idea directory)
 
-3. Find the STOQS project files in the Vagrant synced folder stoqsvm/dev/stoqsgit
+3. Find the STOQS project files in the Vagrant synced folder dev/stoqsgit
 
+4. You may now proceed using either PyCharm or the command line in the VM to work on the STOQS code base
+
+
+[1]: Your virtual machine directory may have a different name, e.g. 'stoqsvm_python3'

--- a/provision.sh
+++ b/provision.sh
@@ -271,6 +271,10 @@ cat <<EOT > .vimrc
 :set shiftwidth=4
 EOT
 
+echo Configure and restart sshd for enabling PyCharm interpreter
+sed -i 's#/usr/lib/openssh/sftp-server#/usr/libexec/openssh/sftp-server#' /etc/ssh/sshd_config
+/usr/bin/systemctl restart sshd
+
 echo Cloning STOQS repo from https://github.com/stoqs/stoqs.git... 
 echo ">>> See CONTRIBUTING.md for how to configure your development system so that you can contribute to STOQS"
 mkdir /vagrant/dev


### PR DESCRIPTION
The /vagrant synced folder is now mounted using NFS which requires the user to enter the host OS's admin password during provisioning. This is likely a necessary annoyance as the NFS performance is much better and the advantages of being able to develop in PyCharm are worth it.

@danellecline @rkahnMBARI I think this is ready for you to use in a parallel VM. After this is merged please install into a 'stoqsvm_python3' folder following instructions at https://github.com/stoqs/stoqs/blob/python3/README.md and https://github.com/stoqs/stoqs/blob/python3/doc/instructions/PYCHARM.md

Thanks!