### PR TITLE
Improve NFS performance

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure("2") do |config|
   config.ssh.forward_x11 = true
   config.ssh.insert_key = false
   config.vm.network :private_network, ip: '192.168.50.50'
-  config.vm.synced_folder '.', '/vagrant', nfs: true
+  config.vm.synced_folder '.', '/vagrant', nfs: true,  mount_options: ['tcp', 'fsc' ,'actimeo=300']
+  config.vbguest.auto_update = false
   config.vm.provision "shell", path: "provision.sh"
 end

--- a/provision.sh
+++ b/provision.sh
@@ -283,6 +283,7 @@ mkdir /vagrant/dev
 cd /vagrant/dev
 git clone -b python3 --depth=50 https://github.com/stoqs/stoqs.git stoqsgit
 cd stoqsgit
+git config core.preloadindex true
 export PATH="/usr/local/bin:$PATH"
 python3.6 -m venv venv-stoqs
 

--- a/provision.sh
+++ b/provision.sh
@@ -118,7 +118,7 @@ then
     yum -y install proj-nad proj-epsg libxml2-devel libxslt-devel pam-devel
     yum -y install python-psycopg2 libpqxx-devel hdf hdf-devel freetds-devel postgresql-devel
     yum -y install gdal-python mapserver mapserver-python libxml2 libxml2-python python-lxml python-pip python-devel gcc mlocate
-    yum -y install scipy blas blas-devel lapack lapack-devel lvm2 firefox
+    yum -y install scipy blas blas-devel lapack lapack-devel lvm2 firefox cachefilesd
     yum -y groups install "GNOME Desktop"
     yum -y install fftw-devel motif-devel ghc-OpenGL-devel
     # For InstantReality's aopt command referenced in doc/instructions/SPATIAL_3d.md
@@ -176,7 +176,7 @@ cat <<EOT > DATA/Model_atlas_v1
 EOT
 popd
 
-echo Build and install MB-System, setting overcommit_memory to wizardry mode
+echo Build and install MB-System, set overcommit_memory to wizardry mode
 wget -q -N ftp://ftp.ldeo.columbia.edu/pub/MB-System/mbsystem-5.5.2284.tar.gz
 tar -xzf mbsystem-5.5.2284.tar.gz
 cd mbsystem-5.5.2284/
@@ -222,6 +222,8 @@ rabbitmqctl set_permissions -p stoqs stoqs ".*" ".*" ".*"
 /usr/bin/systemctl start httpd.service
 /usr/bin/systemctl enable memcached.service
 /usr/bin/systemctl start memcached.service
+/usr/bin/systemctl enable cachefilesd
+/usr/bin/systemctl start cachefilesd
 
 echo Modify pg_hba.conf
 mv -f /var/lib/pgsql/9.6/data/pg_hba.conf /var/lib/pgsql/9.6/data/pg_hba.conf.bak

--- a/stoqs/contrib/analysis/crossproduct_biplots.py
+++ b/stoqs/contrib/analysis/crossproduct_biplots.py
@@ -1,23 +1,9 @@
 #!/usr/bin/env python
-
-__author__ = "Mike McCann"
-__copyright__ = "Copyright 2013, MBARI"
-__license__ = "GPL"
-__maintainer__ = "Mike McCann"
-__email__ = "mccann at mbari.org"
-__status__ = "Development"
-__doc__ = '''
-
+'''
 Script to create biplots of a cross product of all Parameters in a database.
 
 Mike McCann
 MBARI 10 February 2014
-
-@var __date__: Date of last svn commit
-@undocumented: __doc__ parser
-@author: __author__
-@status: __status__
-@license: __license__
 '''
 
 import os


### PR DESCRIPTION
Following suggestions made at https://www.jverdeyen.be/vagrant/speedup-vagrant-nfs/ the NFS attribute cache timeout is set to 5 minutes. From a terminal login to the VM an initial `git status` takes more than 30 seconds. While the attributes are cached it takes less than .2 seconds. So, a git status/add/commit/push session from the VM command line should be completed in 5 minutes to avoid frustration.

As the stoqsgit repository is actually now on the Host OS, a git session there won't have this problem (i.e. performance from PyCharm will be much better).