### PR TITLE
Fix the  --append option for our load scripts

### DIFF
--- a/stoqs/loaders/loadMoreData.py
+++ b/stoqs/loaders/loadMoreData.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+'''
+Script to append a small amount of mooring data to an activity already
+in the default database.  This is meant for testing the --append option
+for our load scripts.
+
+Mike McCann
+MBARI 6 September 2018
+'''
+
+import datetime
+from CANON import CANONLoader
+import timing
+
+# Assign input data sources - use locally served x3d terrain data
+cl = CANONLoader('default', 'Initial Test Database')
+
+# Assign input data sets from OPeNDAP URLs pointing to Discrete Sampling Geometry CF-NetCDF sources
+# - TimeSeries and TimeSeriesProfile
+cl.m1_base = 'http://dods.mbari.org/opendap/data/ssdsdata/deployments/m1/'
+cl.m1_files = [ '201010/OS_M1_20101027hourly_CMSTV.nc',
+                '201010/m1_hs2_20101027.nc',
+              ]
+cl.m1_parms = [ 'northward_sea_water_velocity_HR', 'SEA_WATER_SALINITY_HR', 
+                'SEA_WATER_TEMPERATURE_HR', 'AIR_TEMPERATURE_HR', 'bb470', 'fl676'
+              ]
+cl.m1_startDatetime = datetime.datetime(2010, 10, 27)
+cl.m1_endDatetime = datetime.datetime(2010, 10, 29, 4)
+
+
+# Execute the load
+cl.process_command_line()
+
+if cl.args.test:
+    cl.loadM1(stride=10)
+
+elif cl.args.optimal_stride:
+    cl.loadM1(stride=1)
+
+else:
+    cl.loadM1(stride=2)
+
+print("All Done.")
+

--- a/stoqs/stoqs/tests/load_data.py
+++ b/stoqs/stoqs/tests/load_data.py
@@ -42,7 +42,7 @@ loader.load(campaigns, create_only=True)
 # Load only the March 2016 event lores Mooring data
 campaign.lores_event_times = [campaign.lores_event_times[1]]
 campaign.hires_event_times = []
-campaign.load_cce_moorings(low_res_stride=500, start_mooring=2, end_mooring=3)
+campaign.load_ccemoorings_ev(low_res_stride=500, start_mooring=2, end_mooring=3)
 
 # Add Trajectory data for the same time period
 l_662_url = 'http://legacy.cencoos.org/thredds/dodsC/gliders/Line66/OS_Glider_L_662_20151124_TS.nc'

--- a/test.sh
+++ b/test.sh
@@ -89,6 +89,13 @@ then
         exit -1
     fi
 
+    coverage run --include="loaders/__in*,loaders/DAP*,loaders/Samp*" loaders/loadMoreData.py --append
+    if [ $? != 0 ]
+    then
+        echo "loaders/loadMoreData.py failed to load more data to existing Activity; exiting test.sh."
+        exit -1
+    fi
+
     # Label some data in the test database
     coverage run -a --include="contrib/analysis/classify.py" contrib/analysis/classify.py \
       --createLabels --groupName Plankton --database default  --platform dorado \


### PR DESCRIPTION
The refactoring to use `bulk_create()` has apparently broken the `--append` option that we use during campaign operations to append data to existing Activities. If new data get added to an existing NetCDF file the load fails  with errors like this:
```
django.db.utils.IntegrityError: duplicate key value violates unique constraint "stoqs_measuredparameter_measurement_id_parameter_1328c3fb_uniq"
DETAIL:  Key (measurement_id, parameter_id)=(1410, 12) already exists.
```
The fix likely entails finding the last time in the database for the Activity and using that for the beginning index for the constraint expression for the DAP access to the NetCDF file.

Furthermore, we need a new test to detect whether we've broken this important feature.