### PR TITLE
Replace deprecated griddata() with 'equivalent' method from scipy.interpolate

### DIFF
--- a/docker/requirements/base.txt
+++ b/docker/requirements/base.txt
@@ -60,4 +60,4 @@ sphinx-rtd-theme==0.4.1
 sqlparse==0.2.4
 thredds-crawler==1.5.4
 watchdog==0.9.0
-websocket-client==0.48
+websocket-client==0.53.0

--- a/docker/requirements/base.txt
+++ b/docker/requirements/base.txt
@@ -27,7 +27,7 @@ jupyter==1.0.0
 kombu==4.2.1
 lxml==4.2.4
 mock==2.0.0
-matplotlib==2.2.3
+matplotlib==3.0.0
 netifaces==0.10.7
 nose==1.3.7
 oauthlib==2.1.0

--- a/stoqs/utils/Viz/plotting.py
+++ b/stoqs/utils/Viz/plotting.py
@@ -579,7 +579,7 @@ class MeasuredParameter(BaseParameter):
                 try:
                     self.logger.debug('Gridding data with sdt_count = %d, and y_count = %d', sdt_count, y_count)
                     # See https://scipy-cookbook.readthedocs.io/items/Matplotlib_Gridding_irregularly_spaced_data.html
-                    zi = griddata((cx, cy), cz, (xi[None,:], yi[:,None]), method='cubic')
+                    zi = griddata((cx, cy), cz, (xi[None,:], yi[:,None]), method='cubic', rescale=True)
                 except KeyError as e:
                     self.logger.exception('Got KeyError. Could not grid the data')
                     return None, None, 'Got KeyError. Could not grid the data'
@@ -653,7 +653,7 @@ class MeasuredParameter(BaseParameter):
                         ax.scatter([xs[1]], [0], marker='o', c='w', s=15, zorder=10, edgecolors='k')
 
                 if self.contourParameterID is not None:
-                    zli = griddata((clx, cly), clz, (xi[None,:], yi[:,None]), method='cubic')
+                    zli = griddata((clx, cly), clz, (xi[None,:], yi[:,None]), method='cubic', rescale=True)
                     CS = ax.contour(xi, yi, zli, colors='white')
                     ax.clabel(CS, fontsize=9, inline=1)
 

--- a/stoqs/utils/Viz/plotting.py
+++ b/stoqs/utils/Viz/plotting.py
@@ -13,7 +13,7 @@ import cmocean
 import math
 import matplotlib.pyplot as plt
 from matplotlib import rcParams
-from matplotlib.mlab import griddata
+from scipy.interpolate import griddata
 from matplotlib.colors import hex2color
 from pylab import polyval
 from collections import namedtuple
@@ -578,7 +578,8 @@ class MeasuredParameter(BaseParameter):
             if contourFlag:
                 try:
                     self.logger.debug('Gridding data with sdt_count = %d, and y_count = %d', sdt_count, y_count)
-                    zi = griddata(cx, cy, cz, xi, yi, interp='nn')
+                    # See https://scipy-cookbook.readthedocs.io/items/Matplotlib_Gridding_irregularly_spaced_data.html
+                    zi = griddata((cx, cy), cz, (xi[None,:], yi[:,None]), method='cubic')
                 except KeyError as e:
                     self.logger.exception('Got KeyError. Could not grid the data')
                     return None, None, 'Got KeyError. Could not grid the data'
@@ -652,7 +653,7 @@ class MeasuredParameter(BaseParameter):
                         ax.scatter([xs[1]], [0], marker='o', c='w', s=15, zorder=10, edgecolors='k')
 
                 if self.contourParameterID is not None:
-                    zli = griddata(clx, cly, clz, xi, yi, interp='nn')
+                    zli = griddata((clx, cly), clz, (xi[None,:], yi[:,None]), method='cubic')
                     CS = ax.contour(xi, yi, zli, colors='white')
                     ax.clabel(CS, fontsize=9, inline=1)
 


### PR DESCRIPTION
Addresses https://github.com/stoqs/stoqs/issues/734