### PR TITLE
Still trying to get Dockerhub Autotest to work

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -94,4 +94,6 @@ services:
 
   # Autotest on hub.docker.com - test.sh executed on first start by stoqs-start.sh
   sut:
+    build:
+      context: .
     command: /bin/bash


### PR DESCRIPTION
Hope this fixes this error:
```
Starting Test in docker-compose.test.yml...
The Compose file is invalid because:
Service sut has neither an image nor a build context specified. At least one must be provided.
building docker-compose.test.yml (1)
```