### PR TITLE
Prepend platform name to Activity name

### DIFF
--- a/stoqs/loaders/CANON/__init__.py
+++ b/stoqs/loaders/CANON/__init__.py
@@ -200,9 +200,9 @@ class CANONLoader(LoadScript):
             url = os.path.join(base, f)
             # shorten the activity names
             if 'slate.nc' in aname or 'shore' in aname:
-                aname = '_'.join(aname.split('/')[-2:])
+                aname = f"{pname}_{'_'.join(aname.split('/')[-2:])}"
             else:
-                aname = aname.rsplit('/', 1)[-1]
+                aname = f"{pname}_{aname.rsplit('/', 1)[-1]}"
             if hasattr(self, f'{pname}_aux_coords'):
                 aux_coords = getattr(self, f'{pname}_aux_coords')
             else:


### PR DESCRIPTION
I had wanted to do this for a while so that the name appeared in the mouseover in the STOQS UI. It finally became required once there were two identical file names from two different platforms:
```
[mccann@elvis LRAUV]$ find . -name 201909122002_201909122048_2S_scieng.nc
./triton/missionlogs/2019/20190912_20190912/20190912T200238/201909122002_201909122048_2S_scieng.nc
./pontus/missionlogs/2019/20190821_20190912/20190912T200257/201909122002_201909122048_2S_scieng.nc
```