### PR TITLE
Add flask_sqlalchemy as that now seems to be required by Pandas

### DIFF
--- a/docker/requirements/base.txt
+++ b/docker/requirements/base.txt
@@ -19,6 +19,7 @@ GitPython==3.1.26
 euclid==1.2
 djangorestframework==3.13.1
 fastparquet==0.7.2
+Flask-SQLAlchemy==2.5.1
 httplib2==0.20.2
 hvplot==0.7.2
 holoviews==1.14.7


### PR DESCRIPTION
Let's see if this fixes the Dockerhub build…