### PR TITLE
Revert back to 256 default num_colors, fixing nagging bug in changing colormaps

### DIFF
--- a/stoqs/utils/Viz/plotting.py
+++ b/stoqs/utils/Viz/plotting.py
@@ -97,7 +97,7 @@ class BaseParameter(object):
     def __init__(self):
         # Default colormap - a perceptually uniform, color blind safe one
         self.cm_name = 'cividis'
-        self.num_colors = 512
+        self.num_colors = 256
         self.cmin = None
         self.cmax = None
         self.cm = plt.get_cmap(self.cm_name)


### PR DESCRIPTION
Here's the change that broke it:

https://github.com/stoqs/stoqs/commit/70fd4f5774b6f7c863a481d4ea6ffabc49dd3ec0#diff-8ee5cd3d2717129f859bfec989dbcc8ebbe7f0d8d5e84026c2a2598dc184f475R80

2.5 years ago!